### PR TITLE
update witherbone

### DIFF
--- a/src/main/resources/data/iafgear/silentgear_materials/witherbone.json
+++ b/src/main/resources/data/iafgear/silentgear_materials/witherbone.json
@@ -18,9 +18,9 @@
   "stats": {
     "rod": {
       "melee_damage": {
-        "mul2": 0.2
+        "mul2": 0.25
       },
-      "rarity": 8.0
+      "rarity": 16.0
     }
   },
   "traits": {


### PR DESCRIPTION
the base bone option can be used as either main or as rod, the witherbone has the exact same stats as the vanilla bone for rod other than the tier, but cant be a main part, which means that the witherbone even though harder to acquire is practically a lesser component that can be used in more powerful tools.
this gives a minor (.05%) buff to the part. I would also potentially recommend adding a trait for giving wither effect for a small period of time.